### PR TITLE
Fix error handling

### DIFF
--- a/test/test_package_loading.py
+++ b/test/test_package_loading.py
@@ -132,6 +132,14 @@ def test_different_ABI(selenium_standalone):
     finally:
         (build_dir / 'numpy-broken.js').unlink()
 
+    selenium_standalone.load_package('kiwisolver')
+    selenium_standalone.run('import kiwisolver')
+    assert (
+        selenium_standalone.run('repr(kiwisolver)') ==
+        "<module 'kiwisolver' from "
+        "'/lib/python3.7/site-packages/kiwisolver.so'>"
+    )
+
 
 def test_load_handle_failure(selenium_standalone):
     selenium = selenium_standalone


### PR DESCRIPTION
This makes the ABI check error handling work correctly:

- checkABI throws an actual exception
- It is handled by a `window.addEventListenter('error', ...`) handler that only exists as long as the packages are being loaded. When an error is thrown, it cleans up after itself so that further calls to `loadPackage` will happen correctly.

It also includes a bugfix for WASM prefetching (that was recently broken) that will also be made on master soon...